### PR TITLE
Adding Laravel 6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "OpenStack filesystem service provider for Laravel",
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1 - 5.7",
-        "illuminate/filesystem": "5.1 - 5.7",
+        "illuminate/support": "5.1 - 5.8",
+        "illuminate/filesystem": "5.1 - 5.8",
         "league/flysystem-rackspace": "1.0.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "OpenStack filesystem service provider for Laravel",
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1 - 5.6",
-        "illuminate/filesystem": "5.1 - 5.6",
+        "illuminate/support": "5.1 - 5.7",
+        "illuminate/filesystem": "5.1 - 5.7",
         "league/flysystem-rackspace": "1.0.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "OpenStack filesystem service provider for Laravel",
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.1 - 5.8",
-        "illuminate/filesystem": "5.1 - 5.8",
+        "illuminate/support": "5.1 - 5.8|^6.0",
+        "illuminate/filesystem": "5.1 - 5.8|^6.0",
         "league/flysystem-rackspace": "1.0.*"
     },
     "autoload": {


### PR DESCRIPTION
Added compatibility for Laravel 5.7, 5.8 and 6.0 as requested in https://github.com/neoxia/laravel-openstack/issues/5 . Has been tested these versions.

@alexandre-butynski We use this package in quite some projects at our company, so please let me know if you need any assistance in maintaining it.